### PR TITLE
shell: try to avoid loading a custom prompt

### DIFF
--- a/testflows/connect/shell.py
+++ b/testflows/connect/shell.py
@@ -250,7 +250,7 @@ class Shell(Application):
     name = "bash"
     prompt = r'[#\$] '
     new_prompt = "bash# "
-    command = ["/bin/bash", "--noediting"]
+    command = ["/bin/bash", "--noediting", "--norc", "--noprofile"]
     commands = ShellCommands(
         change_prompt="export PS1=\"{}\"",
         get_exitcode="echo $?"


### PR DESCRIPTION
Custom prompts may not match the default regexp
e.g. when they include color escape characters.
So it's better if we try to avoid loading custom
prompts.